### PR TITLE
Update nexmo/laravel version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "nexmo/laravel": "^1.1"
+        "nexmo/laravel": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi,

This PR will update version of nexmo/laravel to 2.0 to fix this issue:

```
Your requirements could not be resolved to an installable set of packages.
Problem 1
    - itainathaniel/nova-nexmo v1.0.0 requires nexmo/laravel ^1.1 -> satisfiable by nexmo/laravel[1.1.0, 1.1.1, 1.1.2].
    - itainathaniel/nova-nexmo v1.0.1 requires nexmo/laravel ^1.1 -> satisfiable by nexmo/laravel[1.1.0, 1.1.1, 1.1.2].
    - nexmo/laravel 1.1.0 requires nexmo/client ^1.0 -> satisfiable by nexmo/client[1.9.0].
    - nexmo/laravel 1.1.1 requires nexmo/client ^1.0 -> satisfiable by nexmo/client[1.9.0].
    - nexmo/laravel 1.1.2 requires nexmo/client ^1.0 -> satisfiable by nexmo/client[1.9.0].
    - Conclusion: don't install nexmo/client 1.9.0
    - Installation request for itainathaniel/nova-nexmo ^1.0 -> satisfiable by itainathaniel/nova-nexmo[v1.0.0, v1.0.1].
```